### PR TITLE
Add tests for camera-based lux sensor utilities

### DIFF
--- a/custom_components/cameralux/__init__.py
+++ b/custom_components/cameralux/__init__.py
@@ -1,27 +1,30 @@
 # custom_components/cameralux/__init__.py
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - optional Home Assistant import for typing
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
 
 from .const import PLATFORMS
 
 
-async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+async def async_setup(hass: "HomeAssistant", config: dict) -> bool:
     # YAML -> UI import is handled in sensor.async_setup_platform (if you keep YAML)
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: "HomeAssistant", entry: "ConfigEntry") -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     # Reload entities when options change
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_reload_entry(hass: "HomeAssistant", entry: "ConfigEntry"):
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: "HomeAssistant", entry: "ConfigEntry") -> bool:
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/cameralux/helpers.py
+++ b/custom_components/cameralux/helpers.py
@@ -1,0 +1,159 @@
+"""Helper utilities for the CameraLux component.
+
+These functions are kept free of Home Assistant dependencies so they can be
+unit-tested in isolation.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+from PIL import Image
+
+from .const import CONF_HEIGHT, CONF_WIDTH, CONF_X, CONF_Y
+
+_LOGGER = logging.getLogger(__name__)
+
+# Resampling fallback (older Pillow)
+try:
+    RESAMPLE = Image.Resampling.LANCZOS  # Pillow >= 9.1
+except Exception:  # noqa: BLE001
+    RESAMPLE = Image.LANCZOS
+
+
+def get_bounded_int(
+    val,
+    default: int = 0,
+    min_value: int | None = None,
+    max_value: int | None = None,
+) -> int:
+    """Coerce a value to int, clamping to [min_value, max_value] when provided."""
+    try:
+        iv = int(val)
+    except (TypeError, ValueError):
+        iv = default
+    if min_value is not None and iv < min_value:
+        iv = min_value
+    if max_value is not None and iv > max_value:
+        iv = max_value
+    return iv
+
+
+def coerce_float(val, default: float) -> float:
+    """Coerce a value to float, returning default on failure."""
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
+
+
+def precompute_inverse_gamma_8bit_lut() -> np.ndarray:
+    """Generate a 256-entry inverse gamma LUT for sRGB 8-bit values."""
+    lut = np.zeros(256, dtype=np.float32)
+    for i in range(256):
+        normalized = i / 255.0
+        if normalized <= 0.04045:
+            lut[i] = normalized / 12.92
+        else:
+            lut[i] = ((normalized + 0.055) / 1.055) ** 2.4
+    return lut
+
+
+INVERSE_GAMMA_LUT = precompute_inverse_gamma_8bit_lut()
+
+
+def crop_image(image: Image.Image, roi_config: Optional[Dict[str, int]]) -> Image.Image:
+    """Crop the image to the provided ROI; treat 0 width/height as full dimension."""
+    if not roi_config:
+        return image
+
+    img_width, img_height = image.size
+    x = roi_config.get(CONF_X, 0) or 0
+    y = roi_config.get(CONF_Y, 0) or 0
+    w = roi_config.get(CONF_WIDTH, 0) or img_width
+    h = roi_config.get(CONF_HEIGHT, 0) or img_height
+
+    x = max(0, min(x, img_width - 1))
+    y = max(0, min(y, img_height - 1))
+    w = min(w, img_width - x)
+    h = min(h, img_height - y)
+
+    if w <= 0 or h <= 0:
+        _LOGGER.warning("Invalid ROI after clamping: %s", roi_config)
+        return image
+
+    _LOGGER.debug("ROI: x=%d, y=%d, width=%d, height=%d", x, y, w, h)
+    return image.crop((x, y, x + w, y + h))
+
+
+def resize_image(image: Image.Image, max_pixels: int) -> Image.Image:
+    """Resize the image if it exceeds max_pixels, preserving aspect ratio."""
+    width, height = image.size
+    total_pixels = width * height
+    if total_pixels <= max_pixels:
+        return image
+
+    scale = math.sqrt(max_pixels / total_pixels)
+    new_w = max(1, int(width * scale))
+    new_h = max(1, int(height * scale))
+
+    _LOGGER.debug(
+        "Scaled from (%d x %d) to (%d x %d) for <= %d px",
+        width,
+        height,
+        new_w,
+        new_h,
+        max_pixels,
+    )
+    return image.resize((new_w, new_h), RESAMPLE)
+
+
+def calculate_image_luminance(image: Image.Image) -> Tuple[float, float]:
+    """Compute average and perceived luminance from an image in linear space."""
+    MODE_GRAYSCALE = "L"
+    MODE_PALETTE = "P"
+    MODE_CMYK = "CMYK"
+    MODE_RGB = "RGB"
+    MODE_RGBA = "RGBA"
+    MODE_16_BIT_GRAYSCALE = "I;16"
+    MODE_FLOAT = "F"
+    MODE_LINEAR = "I"
+
+    if image.mode in [MODE_PALETTE, MODE_CMYK]:
+        image = image.convert(MODE_RGB)
+
+    img_pixels = np.array(image)
+
+    if img_pixels.ndim == 3 and img_pixels.shape[2] > 3:
+        img_pixels = img_pixels[:, :, :3]
+
+    if image.mode == MODE_16_BIT_GRAYSCALE:
+        linearized = img_pixels.astype(np.float32) / 65535.0
+    elif image.mode in [MODE_LINEAR, MODE_FLOAT]:
+        linearized = img_pixels.astype(np.float32)
+    elif image.mode in [MODE_RGB, MODE_RGBA, MODE_GRAYSCALE]:
+        linearized = INVERSE_GAMMA_LUT[img_pixels.astype(np.uint8)]
+    else:
+        try:
+            image = image.convert(MODE_RGB)
+            img_pixels = np.array(image)
+            linearized = INVERSE_GAMMA_LUT[img_pixels.astype(np.uint8)]
+        except Exception as e:  # noqa: BLE001
+            raise ValueError(f"Unsupported image mode: {image.mode}") from e
+
+    if linearized.ndim == 2:
+        y_plane = linearized
+    else:
+        y_plane = (
+            0.2126 * linearized[:, :, 0]
+            + 0.7152 * linearized[:, :, 1]
+            + 0.0722 * linearized[:, :, 2]
+        )
+
+    avg_lum = float(np.mean(y_plane))
+    perceived = float(np.log1p(avg_lum))
+    _LOGGER.debug("luminance avg=%f perceived=%f from %s", avg_lum, perceived, image.mode)
+    return avg_lum, perceived

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ha-cameralux"
+version = "0.1.0"
+description = "Camera-based lux sensor for Home Assistant"
+readme = "README.md"
+requires-python = ">=3.11"
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7",
+    "pillow>=10",
+    "numpy>=1.24",
+]

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -1,0 +1,56 @@
+import math
+from pathlib import Path
+import sys
+
+import pytest
+from PIL import Image
+
+# Ensure the custom component is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from custom_components.cameralux.helpers import (  # noqa: E402
+    calculate_image_luminance,
+    coerce_float,
+    crop_image,
+    get_bounded_int,
+    resize_image,
+)
+
+
+def test_get_bounded_int():
+    assert get_bounded_int("5", default=0, min_value=0, max_value=10) == 5
+    assert get_bounded_int("bad", default=3) == 3
+    assert get_bounded_int(100, default=0, max_value=50) == 50
+    assert get_bounded_int(-5, default=0, min_value=-3) == -3
+
+
+def test_coerce_float():
+    assert coerce_float("2.5", 0.0) == 2.5
+    assert coerce_float("oops", 1.2) == 1.2
+
+
+def test_crop_and_resize_image():
+    image = Image.new("RGB", (100, 100), color="white")
+    roi = {"x": 10, "y": 10, "width": 50, "height": 50}
+    cropped = crop_image(image, roi)
+    assert cropped.size == (50, 50)
+
+    roi_out = {"x": 90, "y": 90, "width": 20, "height": 20}
+    cropped2 = crop_image(image, roi_out)
+    assert cropped2.size == (10, 10)
+
+    big = Image.new("RGB", (1000, 1000), color="white")
+    resized = resize_image(big, max_pixels=10_000)
+    assert resized.size == (100, 100)
+
+
+def test_calculate_image_luminance():
+    white = Image.new("RGB", (10, 10), color=(255, 255, 255))
+    avg, perceived = calculate_image_luminance(white)
+    assert avg == pytest.approx(1.0, rel=1e-3)
+    assert perceived == pytest.approx(math.log1p(1.0), rel=1e-3)
+
+    black = Image.new("RGB", (10, 10), color=(0, 0, 0))
+    avg2, perceived2 = calculate_image_luminance(black)
+    assert avg2 == pytest.approx(0.0, abs=1e-6)
+    assert perceived2 == pytest.approx(0.0, abs=1e-6)


### PR DESCRIPTION
## Summary
- extract helper utilities into standalone module for easier unit testing
- move unique ID generation back into the sensor module
- expand sensor helper tests to cover new module

## Testing
- `pip install numpy pillow`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8e269b890832bbdcde972f9ec660a