### PR TITLE
Fix undefined cfg when setting up entry

### DIFF
--- a/custom_components/cameralux/sensor.py
+++ b/custom_components/cameralux/sensor.py
@@ -176,17 +176,17 @@ async def async_setup_entry(
         )
         image_url = None
 
-        cfg = {
-            CONF_ENTITY_ID: camera_entity,
-            CONF_IMAGE_URL: image_url,
-            CONF_BRIGHTNESS_ROI: data.get(CONF_BRIGHTNESS_ROI, {}),
-            CONF_CALIBRATION_FACTOR: data.get(
-                CONF_CALIBRATION_FACTOR, DEFAULT_CALIBRATION_FACTOR
-            ),
-            CONF_UPDATE_INTERVAL: data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
-            CONF_UNAVAILABLE_BELOW: data.get(CONF_UNAVAILABLE_BELOW),
-            CONF_UNAVAILABLE_ABOVE: data.get(CONF_UNAVAILABLE_ABOVE),
-        }
+    cfg = {
+        CONF_ENTITY_ID: camera_entity,
+        CONF_IMAGE_URL: image_url,
+        CONF_BRIGHTNESS_ROI: data.get(CONF_BRIGHTNESS_ROI, {}),
+        CONF_CALIBRATION_FACTOR: data.get(
+            CONF_CALIBRATION_FACTOR, DEFAULT_CALIBRATION_FACTOR
+        ),
+        CONF_UPDATE_INTERVAL: data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+        CONF_UNAVAILABLE_BELOW: data.get(CONF_UNAVAILABLE_BELOW),
+        CONF_UNAVAILABLE_ABOVE: data.get(CONF_UNAVAILABLE_ABOVE),
+    }
 
     # Use entry.entry_id as the stable unique_id so Options edits never change the entity id.
     async_add_entities(

--- a/tests/test_async_setup_entry.py
+++ b/tests/test_async_setup_entry.py
@@ -1,0 +1,25 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+import sys
+
+# Ensure the custom component is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from custom_components.cameralux.const import CONF_ENTITY_ID
+from custom_components.cameralux.sensor import async_setup_entry
+
+
+class FakeConfigEntry(SimpleNamespace):
+    pass
+
+
+def test_async_setup_entry_with_camera_only():
+    """Ensure async_setup_entry works when only a camera entity is provided."""
+    entry = FakeConfigEntry(data={CONF_ENTITY_ID: "camera.test"}, options={}, entry_id="1")
+    add_entities = MagicMock()
+
+    # Should not raise and should call async_add_entities once
+    asyncio.run(async_setup_entry(None, entry, add_entities))
+    add_entities.assert_called_once()


### PR DESCRIPTION
## Summary
- build sensor config regardless of both camera and image URL being set
- add regression test for `async_setup_entry`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b303f2c832bb06acd2cab6baf18