### PR TITLE
Support None vs zero in options flow

### DIFF
--- a/custom_components/cameralux/config_flow.py
+++ b/custom_components/cameralux/config_flow.py
@@ -123,19 +123,14 @@ class CameraLuxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if not errors:
                 roi_dict: dict = {CONF_ROI_ENABLED: roi_enabled_ui}
 
-                xv = int_if_value(user_input.get(CONF_X))
-                yv = int_if_value(user_input.get(CONF_Y))
-                wv = int_if_value(user_input.get(CONF_WIDTH))
-                hv = int_if_value(user_input.get(CONF_HEIGHT))
-
-                if xv is not None:
-                    roi_dict[CONF_X] = xv
-                if yv is not None:
-                    roi_dict[CONF_Y] = yv
-                if wv is not None:
-                    roi_dict[CONF_WIDTH] = wv
-                if hv is not None:
-                    roi_dict[CONF_HEIGHT] = hv
+                if CONF_X in user_input:
+                    roi_dict[CONF_X] = int_if_value(user_input.get(CONF_X))
+                if CONF_Y in user_input:
+                    roi_dict[CONF_Y] = int_if_value(user_input.get(CONF_Y))
+                if CONF_WIDTH in user_input:
+                    roi_dict[CONF_WIDTH] = int_if_value(user_input.get(CONF_WIDTH))
+                if CONF_HEIGHT in user_input:
+                    roi_dict[CONF_HEIGHT] = int_if_value(user_input.get(CONF_HEIGHT))
 
                 data = {
                     "name": name_def,
@@ -181,61 +176,31 @@ class CameraLuxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         fields[vol.Optional(CONF_UPDATE_INTERVAL, default=interval_def)] = (
             selector.selector({"number": {"min": 5, "step": 1, "mode": "box"}})
         )
-        if unavail_below_def is not None:
-            fields[vol.Optional(CONF_UNAVAILABLE_BELOW, default=unavail_below_def)] = (
-                selector.selector({"number": {"min": 0, "mode": "box"}})
-            )
-        else:
-            fields[vol.Optional(CONF_UNAVAILABLE_BELOW)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
-        if unavail_above_def is not None:
-            fields[vol.Optional(CONF_UNAVAILABLE_ABOVE, default=unavail_above_def)] = (
-                selector.selector({"number": {"min": 0, "mode": "box"}})
-            )
-        else:
-            fields[vol.Optional(CONF_UNAVAILABLE_ABOVE)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
+        fields[vol.Optional(CONF_UNAVAILABLE_BELOW)] = selector.selector(
+            {"number": {"min": 0, "mode": "box"}}
+        )
+        fields[vol.Optional(CONF_UNAVAILABLE_ABOVE)] = selector.selector(
+            {"number": {"min": 0, "mode": "box"}}
+        )
         fields[vol.Required(UI_ROI_ENABLED, default=roi_enabled_ui)] = (
             selector.selector({"boolean": {}})
         )
 
-        if x_def is not None:
-            fields[vol.Optional(CONF_X, default=x_def)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
-        else:
-            fields[vol.Optional(CONF_X)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
+        fields[vol.Optional(CONF_X)] = selector.selector(
+            {"number": {"min": 0, "mode": "box"}}
+        )
 
-        if y_def is not None:
-            fields[vol.Optional(CONF_Y, default=y_def)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
-        else:
-            fields[vol.Optional(CONF_Y)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
+        fields[vol.Optional(CONF_Y)] = selector.selector(
+            {"number": {"min": 0, "mode": "box"}}
+        )
 
-        if w_def is not None:
-            fields[vol.Optional(CONF_WIDTH, default=w_def)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
-        else:
-            fields[vol.Optional(CONF_WIDTH)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
+        fields[vol.Optional(CONF_WIDTH)] = selector.selector(
+            {"number": {"min": 0, "mode": "box"}}
+        )
 
-        if h_def is not None:
-            fields[vol.Optional(CONF_HEIGHT, default=h_def)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
-        else:
-            fields[vol.Optional(CONF_HEIGHT)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
+        fields[vol.Optional(CONF_HEIGHT)] = selector.selector(
+            {"number": {"min": 0, "mode": "box"}}
+        )
 
         return self.async_show_form(
             step_id="user", data_schema=vol.Schema(fields), errors=errors
@@ -258,21 +223,13 @@ class CameraLuxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         roi: dict = {CONF_ROI_ENABLED: bool(roi_yaml.get(CONF_ROI_ENABLED, False))}
 
         if CONF_X in roi_yaml:
-            xv = int_if_value(roi_yaml.get(CONF_X))
-            if xv is not None:
-                roi[CONF_X] = xv
+            roi[CONF_X] = int_if_value(roi_yaml.get(CONF_X))
         if CONF_Y in roi_yaml:
-            yv = int_if_value(roi_yaml.get(CONF_Y))
-            if yv is not None:
-                roi[CONF_Y] = yv
+            roi[CONF_Y] = int_if_value(roi_yaml.get(CONF_Y))
         if CONF_WIDTH in roi_yaml:
-            wv = int_if_value(roi_yaml.get(CONF_WIDTH))
-            if wv is not None:
-                roi[CONF_WIDTH] = wv
+            roi[CONF_WIDTH] = int_if_value(roi_yaml.get(CONF_WIDTH))
         if CONF_HEIGHT in roi_yaml:
-            hv = int_if_value(roi_yaml.get(CONF_HEIGHT))
-            if hv is not None:
-                roi[CONF_HEIGHT] = hv
+            roi[CONF_HEIGHT] = int_if_value(roi_yaml.get(CONF_HEIGHT))
 
         data = {
             "name": name,
@@ -350,19 +307,22 @@ class CameraLuxOptionsFlow(config_entries.OptionsFlow):
 
             roi_new: dict = {CONF_ROI_ENABLED: roi_enabled_in}
 
-            xv = int_if_value(user_input.get(CONF_X))
-            yv = int_if_value(user_input.get(CONF_Y))
-            wv = int_if_value(user_input.get(CONF_WIDTH))
-            hv = int_if_value(user_input.get(CONF_HEIGHT))
-
-            if xv is not None:
-                roi_new[CONF_X] = xv
-            if yv is not None:
-                roi_new[CONF_Y] = yv
-            if wv is not None:
-                roi_new[CONF_WIDTH] = wv
-            if hv is not None:
-                roi_new[CONF_HEIGHT] = hv
+            if CONF_X in user_input:
+                x_val = int_if_value(user_input.get(CONF_X))
+                if x_val is not None:
+                    roi_new[CONF_X] = x_val
+            if CONF_Y in user_input:
+                y_val = int_if_value(user_input.get(CONF_Y))
+                if y_val is not None:
+                    roi_new[CONF_Y] = y_val
+            if CONF_WIDTH in user_input:
+                w_val = int_if_value(user_input.get(CONF_WIDTH))
+                if w_val is not None:
+                    roi_new[CONF_WIDTH] = w_val
+            if CONF_HEIGHT in user_input:
+                h_val = int_if_value(user_input.get(CONF_HEIGHT))
+                if h_val is not None:
+                    roi_new[CONF_HEIGHT] = h_val
 
             if source == SOURCE_CAMERA and not entity_in:
                 errors[CONF_ENTITY_ID] = "required"
@@ -372,14 +332,22 @@ class CameraLuxOptionsFlow(config_entries.OptionsFlow):
             if not errors:
                 new_opts = {
                     CONF_SOURCE: source,
-                    CONF_ENTITY_ID: entity_in if source == SOURCE_CAMERA else None,
-                    CONF_IMAGE_URL: url_in if source == SOURCE_URL else None,
                     CONF_CALIBRATION_FACTOR: float(cal_in),
                     CONF_UPDATE_INTERVAL: int(interval_in),
                     CONF_BRIGHTNESS_ROI: roi_new,
-                    CONF_UNAVAILABLE_BELOW: unavail_below_in,
-                    CONF_UNAVAILABLE_ABOVE: unavail_above_in,
                 }
+                if source == SOURCE_CAMERA and entity_in is not None:
+                    new_opts[CONF_ENTITY_ID] = entity_in
+                if source == SOURCE_URL and url_in:
+                    new_opts[CONF_IMAGE_URL] = url_in
+                if unavail_below_in is not None:
+                    new_opts[CONF_UNAVAILABLE_BELOW] = unavail_below_in
+                elif data.get(CONF_UNAVAILABLE_BELOW) == 0:
+                    new_opts[CONF_UNAVAILABLE_BELOW] = 0
+                if unavail_above_in is not None:
+                    new_opts[CONF_UNAVAILABLE_ABOVE] = unavail_above_in
+                elif data.get(CONF_UNAVAILABLE_ABOVE) == 0:
+                    new_opts[CONF_UNAVAILABLE_ABOVE] = 0
                 return self.async_create_entry(title="", data=new_opts)
 
             source_def = source
@@ -424,62 +392,32 @@ class CameraLuxOptionsFlow(config_entries.OptionsFlow):
             selector.selector({"number": {"min": 5, "step": 1, "mode": "box"}})
         )
 
-        if unavail_below_def is not None:
-            fields[vol.Optional(CONF_UNAVAILABLE_BELOW, default=unavail_below_def)] = (
-                selector.selector({"number": {"min": 0, "mode": "box"}})
-            )
-        else:
-            fields[vol.Optional(CONF_UNAVAILABLE_BELOW)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
-        if unavail_above_def is not None:
-            fields[vol.Optional(CONF_UNAVAILABLE_ABOVE, default=unavail_above_def)] = (
-                selector.selector({"number": {"min": 0, "mode": "box"}})
-            )
-        else:
-            fields[vol.Optional(CONF_UNAVAILABLE_ABOVE)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
+        fields[vol.Optional(CONF_UNAVAILABLE_BELOW)] = selector.selector(
+            {"number": {"min": 0, "mode": "box"}}
+        )
+        fields[vol.Optional(CONF_UNAVAILABLE_ABOVE)] = selector.selector(
+            {"number": {"min": 0, "mode": "box"}}
+        )
 
         fields[vol.Required(UI_ROI_ENABLED, default=roi_enabled_def)] = (
             selector.selector({"boolean": {}})
         )
 
-        if x_def is not None:
-            fields[vol.Optional(CONF_X, default=x_def)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
-        else:
-            fields[vol.Optional(CONF_X)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
+        fields[vol.Optional(CONF_X)] = selector.selector(
+            {"number": {"min": 0, "mode": "box"}}
+        )
 
-        if y_def is not None:
-            fields[vol.Optional(CONF_Y, default=y_def)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
-        else:
-            fields[vol.Optional(CONF_Y)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
+        fields[vol.Optional(CONF_Y)] = selector.selector(
+            {"number": {"min": 0, "mode": "box"}}
+        )
 
-        if w_def is not None:
-            fields[vol.Optional(CONF_WIDTH, default=w_def)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
-        else:
-            fields[vol.Optional(CONF_WIDTH)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
+        fields[vol.Optional(CONF_WIDTH)] = selector.selector(
+            {"number": {"min": 0, "mode": "box"}}
+        )
 
-        if h_def is not None:
-            fields[vol.Optional(CONF_HEIGHT, default=h_def)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
-        else:
-            fields[vol.Optional(CONF_HEIGHT)] = selector.selector(
-                {"number": {"min": 0, "mode": "box"}}
-            )
+        fields[vol.Optional(CONF_HEIGHT)] = selector.selector(
+            {"number": {"min": 0, "mode": "box"}}
+        )
 
         return self.async_show_form(
             step_id="edit", data_schema=vol.Schema(fields), errors=errors

--- a/tests/test_config_flow_options.py
+++ b/tests/test_config_flow_options.py
@@ -1,0 +1,181 @@
+import asyncio
+from types import SimpleNamespace
+
+from custom_components.cameralux.config_flow import CameraLuxOptionsFlow, UI_ROI_ENABLED
+from custom_components.cameralux.const import (
+    CONF_BRIGHTNESS_ROI,
+    CONF_CALIBRATION_FACTOR,
+    CONF_ENTITY_ID,
+    CONF_HEIGHT,
+    CONF_ROI_ENABLED,
+    CONF_SOURCE,
+    CONF_UNAVAILABLE_ABOVE,
+    CONF_UNAVAILABLE_BELOW,
+    CONF_UPDATE_INTERVAL,
+    CONF_WIDTH,
+    CONF_X,
+    CONF_Y,
+    SOURCE_CAMERA,
+)
+
+
+class DummyEntry(SimpleNamespace):
+    pass
+
+
+def run_flow(flow, user_input):
+    return asyncio.run(flow.async_step_edit(user_input))
+
+
+def test_unavailable_thresholds_allow_zero_and_none():
+    entry = DummyEntry(
+        data={
+            CONF_SOURCE: SOURCE_CAMERA,
+            CONF_ENTITY_ID: "camera.test",
+            CONF_CALIBRATION_FACTOR: 2000.0,
+            CONF_UPDATE_INTERVAL: 30,
+            CONF_BRIGHTNESS_ROI: {CONF_ROI_ENABLED: False},
+            CONF_UNAVAILABLE_BELOW: 5.0,
+            CONF_UNAVAILABLE_ABOVE: 100.0,
+        },
+        options={},
+        entry_id="1",
+    )
+
+    flow = CameraLuxOptionsFlow(entry)
+    result = run_flow(
+        flow,
+        {
+            CONF_SOURCE: SOURCE_CAMERA,
+            CONF_ENTITY_ID: "camera.test",
+            CONF_CALIBRATION_FACTOR: 2000,
+            CONF_UPDATE_INTERVAL: 30,
+            UI_ROI_ENABLED: False,
+            CONF_UNAVAILABLE_BELOW: "",
+            CONF_UNAVAILABLE_ABOVE: "",
+        },
+    )
+    data = result["data"]
+    assert CONF_UNAVAILABLE_BELOW not in data
+    assert CONF_UNAVAILABLE_ABOVE not in data
+
+    entry.options = data
+    flow = CameraLuxOptionsFlow(entry)
+    result = run_flow(
+        flow,
+        {
+            CONF_SOURCE: SOURCE_CAMERA,
+            CONF_ENTITY_ID: "camera.test",
+            CONF_CALIBRATION_FACTOR: 2000,
+            CONF_UPDATE_INTERVAL: 30,
+            UI_ROI_ENABLED: False,
+            CONF_UNAVAILABLE_BELOW: 0,
+            CONF_UNAVAILABLE_ABOVE: 0,
+        },
+    )
+    data = result["data"]
+    assert data[CONF_UNAVAILABLE_BELOW] == 0
+    assert data[CONF_UNAVAILABLE_ABOVE] == 0
+
+    entry.options = data
+    flow = CameraLuxOptionsFlow(entry)
+    result = run_flow(
+        flow,
+        {
+            CONF_SOURCE: SOURCE_CAMERA,
+            CONF_ENTITY_ID: "camera.test",
+            CONF_CALIBRATION_FACTOR: 2000,
+            CONF_UPDATE_INTERVAL: 30,
+            UI_ROI_ENABLED: False,
+            CONF_UNAVAILABLE_BELOW: "",
+            CONF_UNAVAILABLE_ABOVE: "",
+        },
+    )
+    data = result["data"]
+    assert data[CONF_UNAVAILABLE_BELOW] == 0
+    assert data[CONF_UNAVAILABLE_ABOVE] == 0
+
+
+def test_roi_fields_allow_zero_and_none():
+    entry = DummyEntry(
+        data={
+            CONF_SOURCE: SOURCE_CAMERA,
+            CONF_ENTITY_ID: "camera.test",
+            CONF_CALIBRATION_FACTOR: 2000.0,
+            CONF_UPDATE_INTERVAL: 30,
+            CONF_BRIGHTNESS_ROI: {
+                CONF_ROI_ENABLED: True,
+                CONF_X: 1,
+                CONF_Y: 2,
+                CONF_WIDTH: 3,
+                CONF_HEIGHT: 4,
+            },
+        },
+        options={},
+        entry_id="1",
+    )
+
+    flow = CameraLuxOptionsFlow(entry)
+    result = run_flow(
+        flow,
+        {
+            CONF_SOURCE: SOURCE_CAMERA,
+            CONF_ENTITY_ID: "camera.test",
+            CONF_CALIBRATION_FACTOR: 2000,
+            CONF_UPDATE_INTERVAL: 30,
+            UI_ROI_ENABLED: True,
+            CONF_X: "",
+            CONF_Y: "",
+            CONF_WIDTH: "",
+            CONF_HEIGHT: "",
+        },
+    )
+    roi = result["data"][CONF_BRIGHTNESS_ROI]
+    assert CONF_X not in roi
+    assert CONF_Y not in roi
+    assert CONF_WIDTH not in roi
+    assert CONF_HEIGHT not in roi
+
+    entry.options = result["data"]
+    flow = CameraLuxOptionsFlow(entry)
+    result = run_flow(
+        flow,
+        {
+            CONF_SOURCE: SOURCE_CAMERA,
+            CONF_ENTITY_ID: "camera.test",
+            CONF_CALIBRATION_FACTOR: 2000,
+            CONF_UPDATE_INTERVAL: 30,
+            UI_ROI_ENABLED: True,
+            CONF_X: 0,
+            CONF_Y: 0,
+            CONF_WIDTH: 0,
+            CONF_HEIGHT: 0,
+        },
+    )
+    roi = result["data"][CONF_BRIGHTNESS_ROI]
+    assert roi[CONF_X] == 0
+    assert roi[CONF_Y] == 0
+    assert roi[CONF_WIDTH] == 0
+    assert roi[CONF_HEIGHT] == 0
+
+    entry.options = result["data"]
+    flow = CameraLuxOptionsFlow(entry)
+    result = run_flow(
+        flow,
+        {
+            CONF_SOURCE: SOURCE_CAMERA,
+            CONF_ENTITY_ID: "camera.test",
+            CONF_CALIBRATION_FACTOR: 2000,
+            CONF_UPDATE_INTERVAL: 30,
+            UI_ROI_ENABLED: True,
+            CONF_X: "",
+            CONF_Y: "",
+            CONF_WIDTH: "",
+            CONF_HEIGHT: "",
+        },
+    )
+    roi = result["data"][CONF_BRIGHTNESS_ROI]
+    assert CONF_X not in roi
+    assert CONF_Y not in roi
+    assert CONF_WIDTH not in roi
+    assert CONF_HEIGHT not in roi


### PR DESCRIPTION
## Summary
- remove optional config entries when cleared
- preserve explicit 0 for unavailable thresholds
- test threshold and ROI removal and zero persistence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab109f6700832bb1d26731db4da3d6